### PR TITLE
feat: Implemented LM35 Driver with Temperature Reading and BCD Formatting

### DIFF
--- a/firmware/src/api/tempr.c
+++ b/firmware/src/api/tempr.c
@@ -1,12 +1,7 @@
 /**
- * @file tempr.c
- * @author Majdi Richa (majdi.richa@gmail.com)
- * @brief
- * @version 0.1
- * @date 2024-11-18
- *
- * @copyright Copyright (c) 2024
- *
+ * @file    tempr.h
+ * @author  Antoine Karam (antoinekaram1414@gmail.com)
+ * @date    2024-12-21
  */
 
 #include "../main.h"
@@ -15,5 +10,9 @@
 
 float read_temperature(void)
 {
-    return 0;
+    uint8_t adc_val;
+
+    adc_val = get_adc(ADC_TEMPR); // Read ADC
+
+    return (float)adc_val * (MAX_TEMPERATURE / (ADC_MAX_LVL - 1));
 }

--- a/firmware/src/api/tempr.c
+++ b/firmware/src/api/tempr.c
@@ -16,3 +16,22 @@ float read_temperature(void)
 
     return (float)adc_val * (MAX_TEMPERATURE / (ADC_MAX_LVL - 1));
 }
+
+uint8_t read_temperature_BCD_limited(void)
+{
+    float raw_temp = read_temperature(); /* Read the temperature value */
+
+    if (raw_temp > 99)
+    { /* Limit the temperature to a maximum of 99*/
+        raw_temp = 99;
+    }
+
+    uint8_t temp = (uint8_t)raw_temp; /* Convert float to uint8_t for easier extraction*/
+
+    uint8_t first_digit = temp / 10;           /* Extract the first digit */
+    uint8_t second_digit = (uint8_t)temp % 10; /* Extract the second digit */
+
+    uint8_t packed_digits = (second_digit & 0x0F) | ((first_digit << 4) & 0xF0); /* Pack the two digits into one byte */
+
+    return packed_digits;
+}

--- a/firmware/src/api/tempr.c
+++ b/firmware/src/api/tempr.c
@@ -28,8 +28,8 @@ uint8_t read_temperature_BCD_limited(void)
 
     uint8_t temp = (uint8_t)raw_temp; /* Convert float to uint8_t for easier extraction*/
 
-    uint8_t first_digit = temp / 10;           /* Extract the first digit */
-    uint8_t second_digit = (uint8_t)temp % 10; /* Extract the second digit */
+    uint8_t first_digit = temp / 10;  /* Extract the first digit */
+    uint8_t second_digit = temp % 10; /* Extract the second digit */
 
     uint8_t packed_digits = (second_digit & 0x0F) | ((first_digit << 4) & 0xF0); /* Pack the two digits into one byte */
 

--- a/firmware/src/api/tempr.h
+++ b/firmware/src/api/tempr.h
@@ -1,12 +1,7 @@
 /**
- * @file tempr.h
- * @author Majdi Richa (majdi.richa@gmail.com)
- * @brief
- * @version 0.1
- * @date 2024-11-18
- *
- * @copyright Copyright (c) 2024
- *
+ * @file    tempr.h
+ * @author  Antoine Karam (antoinekaram1414@gmail.com)
+ * @date    2024-12-21
  */
 
 #ifndef TEMPR_H
@@ -14,6 +9,11 @@
 
 #define MAX_TEMPERATURE (100.0) // deg C
 
+/**
+ * @brief Get the temperature
+ *
+ * @return float
+ */
 float read_temperature(void);
 
 #endif

--- a/firmware/src/api/tempr.h
+++ b/firmware/src/api/tempr.h
@@ -16,4 +16,11 @@
  */
 float read_temperature(void);
 
+/**
+ * @brief Get the temperature in BCD format limited to 2 digits
+ *
+ * @return uint8_t
+ */
+uint8_t read_temperature_BCD_limited(void);
+
 #endif


### PR DESCRIPTION
## Description

Implemented the LM35 driver with a function to read the temperature and another function to retrieve the temperature in BCD format, limited to two digits. This makes it easier to display the temperature for 7-segment displays.

## Related Issue

#1 and from the project assignment:
> The temperature is delivered by the famous LM35 analog sensor. 

## Screenshots or Demo:

>Note that the task has not been fully integrated with the driver yet. This demo only shows the temperature displayed in (TT dC) format for demonstration purposes.

![image](https://github.com/user-attachments/assets/28e51192-cad2-44a7-8883-7fe9b574a1e0)
