### PR TITLE
feat: Implement floor monitor API + display state

### DIFF
--- a/firmware/src/api/floor.c
+++ b/firmware/src/api/floor.c
@@ -1,0 +1,86 @@
+/**
+ * @file floor.c
+ * @author Ghady Youssef (ghadyyi@gmail.com)
+ * @brief Implementation of the floor monitor API.
+ * @version 0.1
+ * @date 2024-12-28
+ *
+ * @copyright Copyright (c) 2024
+ *
+ */
+
+#include "../main.h"
+#include "floor.h"
+#include "../sched/scheduler.h"
+
+/* Global variables */
+enum floor current_floor; /*!< Contains the global floor state. */
+
+/* Local prototypes */
+
+/**
+ * @brief Task that monitors the floor stop switches and updates global floor state.
+ *
+ * @param me
+ * @param msg
+ * @param arg
+ */
+void floor_state_monitor(s_task_handle_t me, s_task_msg_t **msg, void *arg);
+
+/**
+ * @brief Task retrieves global floor state and displays it to 7-segment display.
+ *
+ * @param me
+ * @param msg
+ * @param arg
+ */
+void display_floor(s_task_handle_t me, s_task_msg_t **msg, void *arg);
+
+bool init_floor_monitor()
+{
+    bool ret = true;
+    ret &= s_task_create(true, S_TASK_NORMAL_PRIORITY, 300, floor_state_monitor, NULL, NULL);
+    ret &= s_task_create(true, S_TASK_NORMAL_PRIORITY, 500, display_floor, NULL, NULL);
+    return ret;
+}
+
+void floor_state_monitor(s_task_handle_t me, s_task_msg_t **msg, void *arg)
+{
+    // Flr3_Stop => PIN A1
+    // Flr2_Stop => PIN A4
+    // Flr1_Stop => PIN A7
+    // Flr0_Stop => PIN C2
+
+    if (!input(PIN_A1)) /* Check Floor 3 Stop */
+    {
+        current_floor = F3;
+    }
+    else if (!input(PIN_A4)) /* Check Floor 2 Stop */
+    {
+        current_floor = F2;
+    }
+    else if (!input(PIN_A7)) /* Check Floor 1 Stop */
+    {
+        current_floor = F1;
+    }
+    else if (!input(PIN_C2)) /* Check Floor 0 Stop */
+    {
+        current_floor = GF;
+    }
+}
+
+void display_floor(s_task_handle_t me, s_task_msg_t **msg, void *arg)
+{
+    enum floor floor = get_current_floor();
+
+    for (uint8_t i = 0; i < 4; ++i)
+    {
+        output_bit(PIN_G0 + i, floor & 0x01);
+        floor >>= 1;
+    }
+}
+
+enum floor get_current_floor()
+{
+    return current_floor;
+}

--- a/firmware/src/api/floor.h
+++ b/firmware/src/api/floor.h
@@ -1,0 +1,37 @@
+/**
+ * @file floor.h
+ * @author Ghady Youssef (ghadyyi@gmail.com)
+ * @brief The API to access the elevator's floor state.
+ * @version 0.1
+ * @date 2024-12-28
+ *
+ * @copyright Copyright (c) 2024
+ *
+ */
+
+/**
+ * @brief A simple representation of the floor values.
+ *
+ */
+enum floor
+{
+    F3 = 3,
+    F2 = 2,
+    F1 = 1,
+    GF = 0,
+};
+
+/**
+ * @brief Initializes a task that monitors the floor state.
+ *
+ * @return true if initialization is successful
+ * @return false otherwise
+ */
+bool init_floor_monitor();
+
+/**
+ * @brief Get the current floor
+ *
+ * @return Floor number
+ */
+enum floor get_current_floor();

--- a/firmware/src/elevator.ccspjt
+++ b/firmware/src/elevator.ccspjt
@@ -40,7 +40,7 @@ enabled=0
 chip=1
 D1=
 V1=
-buildcount=90
+buildcount=101
 
 [main.c]
 Type=4
@@ -58,7 +58,7 @@ Fixed=
 
 [Opened Files]
 1=main.c
-t1=1
+t1=9
 Count=7
 2=drivers\adc.h
 t2=1
@@ -70,7 +70,7 @@ t4=1
 t5=1
 6=api\tempr.c
 t6=1
-7=display_time_date_temp.c
+7=api\floor.c
 t7=1
 8=drivers\ds1307.c
 t8=1
@@ -78,13 +78,13 @@ t8=1
 Type=4
 
 [ProjectLog]
-Days=16
+Days=17
 D1=08-09-2024
 D1_L=4
 D1_L1=[66257]Project Opened.
 D1_L2=[66782]Started Editing.
 D1_L3=[66858]Stopped Editing.
-TotalEdit=35
+TotalEdit=36
 TotalDebug=0
 D1_E=2
 D1_D=0
@@ -236,12 +236,23 @@ D16_L2=[50317]Project Closed.
 D16_L3=[50318]Project Opened.
 D16_L4=[56483]Started Editing.
 D16_L5=[56783]Stopped Editing.
+D17=28-12-2024
+D17_L=7
+D17_L1=[43360]Project Opened.
+D17_L2=[44255]Project Closed.
+D17_L3=[44263]Project Opened.
+D17_L4=[44264]Project Closed.
+D17_L5=[44264]Project Opened.
+D17_L6=[44556]Started Editing.
+D17_L7=[44557]Stopped Editing.
+D17_E=1
+D17_D=0
 [..\output\elevator.c]
 Type=4
 [..\..\..\UART_int_Tasks\Firmware\output\elevator.c]
 Type=4
 [Units]
-Count=9
+Count=10
 1=main
 2=hardware
 3=system
@@ -251,4 +262,5 @@ Count=9
 7=sched\scheduler
 8=drivers\ds1307
 9=api\display_time_date_temp
+10=api\floor
 Link=1

--- a/firmware/src/main.c
+++ b/firmware/src/main.c
@@ -6,6 +6,7 @@
 #include "timer.h"
 #include "drivers/ds1307.h"
 #include "api/display_time_date_temp.h"
+#include "api/floor.h"
 
 void main()
 {
@@ -26,6 +27,7 @@ void main()
         ret &= init_rtc(); /* initilize RTC */
 
         ret &= init_display_time_date_temp(); /* initialize task to cycle and display time, date, and temperature */
+        ret &= init_floor_monitor();          /* initialize task to monitor floor state */
 
         if (true == ret) /*success?*/
         {


### PR DESCRIPTION
## Description

Implemented the floor monitor API in `floor.h/.c`.

The main API is the function below:
```c
enum floor get_current_floor();
```
which returns the current floor state.

Another function is:
```c
bool init_floor_monitor();
```
which initializes:
- a task that periodically checks the floor STOP pins to update the global `current_floor` state
- a task that periodically fetch the global state and reflect it on the 7-segment displays

## Related Issue

Closes #8 and from the assignment:

> **Floor information**
> - One 7-segment-digit display for floor number indication.
>
> **Cabin information**
> - One 7-segment-digit display for floor number indication.

## Screenshots

Here we can see the floor 2 STOP switch toggled and the 7-segment displays correctly show the state of the elevator. When another switch is toggled, the displays change to reflect the correct state.

![image](https://github.com/user-attachments/assets/ee07bfc4-9318-4d88-957c-96034fe5f954)
