### PR TITLE
refactor: Renamed cabin_display module

### DIFF
--- a/firmware/src/api/cabin_display.c
+++ b/firmware/src/api/cabin_display.c
@@ -1,10 +1,10 @@
 /**
- * @file    display_time_date_temp.c
+ * @file    cabin_display.c
  * @author  Antoine Karam (antoinekaram1414@gmail.com)
  * @date    2024-12-21
  */
 #include "../main.h"
-#include "display_time_date_temp.h"
+#include "cabin_display.h"
 #include "tempr.h"
 #include "../hardware.h"
 #include "../sched/scheduler.h"
@@ -20,7 +20,7 @@ void show_temperature();
 /*Global variables:*/
 static uint8_t display_cycle = MIN_COUNT;
 
-bool init_display_time_date_temp(void)
+bool init_cabin_display(void)
 {
     return s_task_create(true, S_TASK_NORMAL_PRIORITY, 10000, display_process, NULL, NULL);
 }

--- a/firmware/src/api/cabin_display.h
+++ b/firmware/src/api/cabin_display.h
@@ -1,11 +1,11 @@
 /**
- * @file    display_time_date_temp.h
+ * @file    cabin_display.h
  * @author  Antoine Karam (antoinekaram1414@gmail.com)
  * @date    2024-12-21
  */
 
-#ifndef DISPLAY_TIME_DATE_TEMP_H
-#define DISPLAY_TIME_DATE_TEMP_H
+#ifndef CABIN_DISPLAY_H
+#define CABIN_DISPLAY_H
 
 /* Starting point for the display cycle counter*/
 #define MIN_COUNT (1)
@@ -20,6 +20,6 @@
  * @return true if the task is successfully created
  * @return false otherwise
  */
-bool init_display_time_date_temp(void);
+bool init_cabin_display(void);
 
 #endif

--- a/firmware/src/elevator.ccspjt
+++ b/firmware/src/elevator.ccspjt
@@ -40,7 +40,7 @@ enabled=0
 chip=1
 D1=
 V1=
-buildcount=351
+buildcount=353
 
 [main.c]
 Type=4
@@ -311,7 +311,7 @@ Count=14
 6=api\tempr
 7=sched\scheduler
 8=drivers\ds1307
-9=api\display_time_date_temp
+9=api\cabin_display
 10=api\floor
 11=api\motor
 12=api\elevator

--- a/firmware/src/main.c
+++ b/firmware/src/main.c
@@ -5,7 +5,7 @@
 #include "system.h"
 #include "timer.h"
 #include "drivers/ds1307.h"
-#include "api/display_time_date_temp.h"
+#include "api/cabin_display.h"
 #include "api/floor.h"
 #include "api/motor.h"
 #include "api/elevator.h"
@@ -29,10 +29,10 @@ void main()
         ret &= init_adc(); /* initialize ADC sampling */
         ret &= init_rtc(); /* initilize RTC */
 
-        ret &= init_display_time_date_temp(); /* initialize task to cycle and display time, date, and temperature */
-        ret &= init_floor_monitor();          /* initialize task to monitor floor state */
-        ret &= init_motor();                  /* initialize task to monitor the motor */
-        ret &= init_elevator_scheduler();     /* initialize the elevator scheduler */
+        ret &= init_cabin_display();      /* initialize task to cycle and display time, date, and temperature */
+        ret &= init_floor_monitor();      /* initialize task to monitor floor state */
+        ret &= init_motor();              /* initialize task to monitor the motor */
+        ret &= init_elevator_scheduler(); /* initialize the elevator scheduler */
 
         ret &= init_buttons();
 


### PR DESCRIPTION
## Description

Renamed `display_time_date_temp` module to `cabin_display`.

