### PR TITLE
fix: Incorrect behavior when calling 'goto_floor' with motor moving

### DIFF
--- a/firmware/src/api/motor.c
+++ b/firmware/src/api/motor.c
@@ -32,25 +32,30 @@ bool init_motor(void)
 
 void goto_floor(uint8_t target_floor)
 {
-    start_floor = get_current_floor(); /* Record the current floor as the starting point */
-
-    end_floor = target_floor; /* Set the target floor */
+    enum floor current_floor = get_current_floor(); /* Get the floor which the elevator is currently at */
 
     enum direction current_direction = get_motor_direction(); /* Get current motor direction */
 
     enum direction new_direction = NONE; /* Determine the new direction */
-    if (start_floor < end_floor)
+    if (current_floor < target_floor)
     { /* Move upward */
         new_direction = UP;
     }
-    else if (start_floor > end_floor)
+    else if (current_floor > target_floor)
     { /* Move downward */
         new_direction = DOWN;
+    }
+
+    /* Record the current floor as the new starting point only when the motor is idle */
+    if (current_direction == NONE)
+    {
+        start_floor = current_floor;
     }
 
     /* Continue only if the motor is not moving or moving in the same direction */
     if (current_direction == NONE || current_direction == new_direction)
     {
+        end_floor = target_floor; /* Set the target floor */
         set_motor_direction(new_direction);
         s_task_resume(monitor_motor_hndl, true); /* Immediately resume the task */
     }


### PR DESCRIPTION
## Description

Fixes the incorrect behavior when calling `goto_floor` while the motor is moving. Previously, the `start_floor` and `end_floor` variables were updated even when the motor was not idle or moving in the opposite direction, leading to a safety hazard in the elevator's state. This fix ensures that these variables are only updated when the motor is idle or moving in the correct direction, preventing unexpected behavior.

### Changes:
- Prevent `start_floor` from being updated when the motor is moving.
- Ensure `end_floor` is only updated when the motor is idle or moving in the same direction as the new target floor.

## Related Issue

Closes #16 
