### PR TITLE
fix: Added blinking to the display separator when time is displayed

### DIFF
--- a/firmware/src/elevator.ccspjt
+++ b/firmware/src/elevator.ccspjt
@@ -40,7 +40,7 @@ enabled=0
 chip=1
 D1=
 V1=
-buildcount=353
+buildcount=357
 
 [main.c]
 Type=4
@@ -94,7 +94,7 @@ t16=1
 Type=4
 
 [ProjectLog]
-Days=21
+Days=22
 D1=08-09-2024
 D1_L=4
 D1_L1=[66257]Project Opened.
@@ -297,6 +297,13 @@ D21_L=3
 D21_L1=[42834]Project Opened.
 D21_L2=[42834]Project Closed.
 D21_L3=[42835]Project Opened.
+D22=09-01-2025
+D22_L=5
+D22_L1=[60613]Project Opened.
+D22_L2=[60614]Project Closed.
+D22_L3=[60615]Project Opened.
+D22_L4=[60635]Project Closed.
+D22_L5=[60635]Project Opened.
 [..\output\elevator.c]
 Type=4
 [..\..\..\UART_int_Tasks\Firmware\output\elevator.c]


### PR DESCRIPTION
## Description

Added blinking functionality that was missing from the cabin display.
