### PR TITLE
refactor: Moved datetime functions into a date API and simplified dri…

### DIFF
--- a/firmware/src/api/cabin_display.c
+++ b/firmware/src/api/cabin_display.c
@@ -8,7 +8,7 @@
 #include "tempr.h"
 #include "../hardware.h"
 #include "../sched/scheduler.h"
-#include "../drivers/ds1307.h"
+#include "date.h"
 
 /*Local prototypes:*/
 void display_process(s_task_handle_t me, s_task_msg_t **msg, void *arg);

--- a/firmware/src/api/date.c
+++ b/firmware/src/api/date.c
@@ -1,0 +1,73 @@
+/**
+ * @file date.c
+ * @author Ghady Youssef (ghadyyi@gmail.com)
+ * @brief
+ * @version 0.1
+ * @date 2025-01-09
+ *
+ * @copyright Copyright (c) 2025
+ *
+ */
+
+#include "main.h"
+#include "date.h"
+#include "../drivers/ds1307.h"
+
+bool get_full_date(date_info_t *bcd_date)
+{
+    bool ack_state = true;
+    uint8_t date, month;
+    ack_state &= get_date(&date);
+    ack_state &= get_month(&month);
+    bcd_date->date = date;
+    bcd_date->month = month;
+    return ack_state;
+}
+
+bool get_time(time_info_t *bcd_time)
+{
+    bool ack_state = true;
+    uint8_t hrs, mins, seconds;
+    ack_state &= get_hour(&hrs);
+    ack_state &= get_minutes(&mins);
+    ack_state &= get_seconds(&seconds);
+    bcd_time->hours = hrs;
+    bcd_time->minutes = mins;
+    bcd_time->seconds = seconds;
+    return ack_state;
+}
+
+bool get_hour(uint8_t *hour)
+{
+    return read_reg(HRS_ADDR, hour);
+}
+
+bool get_minutes(uint8_t *minutes)
+{
+    return read_reg(MINS_ADDR, minutes);
+}
+
+bool get_seconds(uint8_t *seconds)
+{
+    return read_reg(SECS_ADDR, seconds);
+}
+
+bool get_day(uint8_t *day)
+{
+    return read_reg(DAY_ADDR, day);
+}
+
+bool get_date(uint8_t *date)
+{
+    return read_reg(DATE_ADDR, date);
+}
+
+bool get_month(uint8_t *month)
+{
+    return read_reg(MONTH_ADDR, month);
+}
+
+bool get_year(uint8_t *year)
+{
+    return read_reg(YEAR_ADDR, year);
+}

--- a/firmware/src/api/date.h
+++ b/firmware/src/api/date.h
@@ -1,0 +1,109 @@
+/**
+ * @file date.h
+ * @author Ghady Youssef (ghadyyi@gmail.com)
+ * @brief
+ * @version 0.1
+ * @date 2025-01-09
+ *
+ * @copyright Copyright (c) 2025
+ *
+ */
+
+#ifndef DATE_H
+#define DATE_H
+
+typedef struct date_info
+{
+    uint8_t day;   /*!< The day value represented in BCD */
+    uint8_t date;  /*!< The date value represented in BCD */
+    uint8_t month; /*!< The month value represented in BCD */
+    uint8_t year;  /*!< The year value represented in BCD */
+} date_info_t;
+
+typedef struct time_info
+{
+    uint16_t hours;   /*!< The hours value represented in BCD */
+    uint16_t minutes; /*!< The minutes value represented in BCD */
+    uint16_t seconds; /*!< The seconds value represented in BCD */
+} time_info_t;
+
+/**
+ * @brief Get the date in BCD format
+ *
+ * @return true
+ * @return false
+ */
+bool get_full_date(date_info_t *bcd_date);
+
+/**
+ * @brief Get the time in BCD format
+ *
+ * @return true
+ * @return false
+ */
+bool get_time(time_info_t *bcd_time);
+
+/**
+ * @brief Get the hour in BCD format
+ *
+ * @param hour
+ * @return true
+ * @return false
+ */
+bool get_hour(uint8_t *hour);
+
+/**
+ * @brief Get the minutes in BCD format
+ *
+ * @param minutes
+ * @return true
+ * @return false
+ */
+bool get_minutes(uint8_t *minutes);
+
+/**
+ * @brief Get the seconds in BCD format
+ *
+ * @param seconds
+ * @return true
+ * @return false
+ */
+bool get_seconds(uint8_t *seconds);
+
+/**
+ * @brief Get the date in BCD format
+ *
+ * @param date
+ * @return true
+ * @return false
+ */
+bool get_date(uint8_t *date);
+
+/**
+ * @brief Get the day in BCD format
+ *
+ * @param day
+ * @return true
+ * @return false
+ */
+bool get_day(uint8_t *day);
+
+/**
+ * @brief Get the month in BCD format
+ *
+ * @param month
+ * @return true
+ * @return false
+ */
+bool get_month(uint8_t *month);
+
+/**
+ * @brief Get the year in BCD format
+ *
+ * @param year
+ * @return true
+ * @return false
+ */
+bool get_year(uint8_t *year);
+
+#endif

--- a/firmware/src/drivers/ds1307.c
+++ b/firmware/src/drivers/ds1307.c
@@ -1,11 +1,15 @@
 /**
- * @file    ds1307.c
- * @author  Ghaadyy
- * @date    21/12/2024
+ * @file ds1307.c
+ * @author Ghady Youssef (ghadyyi@gmail.com)
+ * @brief The DS1307 driver.
+ * @version 0.2
+ * @date 2024-12-21
+ *
+ * @copyright Copyright (c) 2024
+ *
  */
 
 #include "main.h"
-#include "../sched/scheduler.h"
 #include "ds1307.h"
 
 #define _AND_ACK (1)  /*!< Slave ACK */
@@ -34,129 +38,16 @@ bool init_rtc(void)
     return (0 == ack_state) ? true : false;
 }
 
-bool get_full_date(date_info_t *bcd_date)
-{
-    bool ack_state = true;
-    uint8_t date, month;
-    ack_state &= get_date(&date);
-    ack_state &= get_month(&month);
-    bcd_date->date = date;
-    bcd_date->month = month;
-    return ack_state;
-}
-
-bool get_time(time_info_t *bcd_time)
-{
-    bool ack_state = true;
-    uint8_t hrs, mins, seconds;
-    ack_state &= get_hour(&hrs);
-    ack_state &= get_minutes(&mins);
-    ack_state &= get_seconds(&seconds);
-    bcd_time->hours = hrs;
-    bcd_time->minutes = mins;
-    bcd_time->seconds = seconds;
-    return ack_state;
-}
-
-bool get_hour(uint8_t *hour)
+bool read_reg(uint8_t reg_addr, uint8_t *val)
 {
     uint8_t ack_state = 0;
 
     i2c_start();                                  /* Issue START condition */
     ack_state |= i2c_write(_DS1307_SLAVE_ADDR_W); /* Specify DS1307 slave with WRITE */
-    ack_state |= i2c_write(HRS_ADDR);             /* Select hours register */
+    ack_state |= i2c_write(reg_addr);             /* Select register address */
     i2c_start();                                  /* Issue RESTART condition */
     ack_state |= i2c_write(_DS1307_SLAVE_ADDR_R); /* Specify DS1307 slave with READ */
-    *hour = i2c_read(_AND_NACK);                  /* Read hour register */
-    i2c_stop();                                   /* Issue STOP condition */
-
-    return (0 == ack_state) ? true : false;
-}
-
-bool get_minutes(uint8_t *minutes)
-{
-    uint8_t ack_state = 0;
-
-    i2c_start();                                  /* Issue START condition */
-    ack_state |= i2c_write(_DS1307_SLAVE_ADDR_W); /* Specify DS1307 slave with WRITE */
-    ack_state |= i2c_write(MINS_ADDR);            /* Select minutes register */
-    i2c_start();                                  /* Issue RESTART condition */
-    ack_state |= i2c_write(_DS1307_SLAVE_ADDR_R); /* Specify DS1307 slave with READ */
-    *minutes = i2c_read(_AND_NACK);               /* Read minutes register */
-    i2c_stop();                                   /* Issue STOP condition */
-
-    return (0 == ack_state) ? true : false;
-}
-
-bool get_seconds(uint8_t *seconds)
-{
-    uint8_t ack_state = 0;
-
-    i2c_start();                                  /* Issue START condition */
-    ack_state |= i2c_write(_DS1307_SLAVE_ADDR_W); /* Specify DS1307 slave with WRITE */
-    ack_state |= i2c_write(SECS_ADDR);            /* Select seconds register */
-    i2c_start();                                  /* Issue RESTART condition */
-    ack_state |= i2c_write(_DS1307_SLAVE_ADDR_R); /* Specify DS1307 slave with READ */
-    *seconds = i2c_read(_AND_NACK) & 0x7F;        /* Read seconds register */
-    i2c_stop();                                   /* Issue STOP condition */
-
-    return (0 == ack_state) ? true : false;
-}
-
-bool get_day(uint8_t *day)
-{
-    uint8_t ack_state = 0;
-
-    i2c_start();                                  /* Issue START condition */
-    ack_state |= i2c_write(_DS1307_SLAVE_ADDR_W); /* Specify DS1307 slave */
-    ack_state |= i2c_write(DAY_ADDR);             /* Get day */
-    i2c_start();                                  /* Issue RESTART condition */
-    uint8_t day_raw = i2c_read(_AND_NACK);        /* Read day register */
-    i2c_stop();                                   /* Issue STOP condition */
-
-    return (0 == ack_state) ? true : false;
-}
-
-bool get_date(uint8_t *date)
-{
-    uint8_t ack_state = 0;
-
-    i2c_start();                                  /* Issue START condition */
-    ack_state |= i2c_write(_DS1307_SLAVE_ADDR_W); /* Specify DS1307 slave with WRITE */
-    ack_state |= i2c_write(DATE_ADDR);            /* Select date register */
-    i2c_start();                                  /* Issue RESTART condition */
-    ack_state |= i2c_write(_DS1307_SLAVE_ADDR_R); /* Specify DS1307 slave with READ */
-    *date = i2c_read(_AND_NACK);                  /* Read date register */
-    i2c_stop();                                   /* Issue STOP condition */
-
-    return (0 == ack_state) ? true : false;
-}
-
-bool get_month(uint8_t *month)
-{
-    uint8_t ack_state = 0;
-
-    i2c_start();                                  /* Issue START condition */
-    ack_state |= i2c_write(_DS1307_SLAVE_ADDR_W); /* Specify DS1307 slave with WRITE */
-    ack_state |= i2c_write(MONTH_ADDR);           /* Select month register */
-    i2c_start();                                  /* Issue RESTART condition */
-    ack_state |= i2c_write(_DS1307_SLAVE_ADDR_R); /* Specify DS1307 slave with READ */
-    *month = i2c_read(_AND_NACK);                 /* Read month register */
-    i2c_stop();                                   /* Issue STOP condition */
-
-    return (0 == ack_state) ? true : false;
-}
-
-bool get_year(uint8_t *year)
-{
-    uint8_t ack_state = 0;
-
-    i2c_start();                                  /* Issue START condition */
-    ack_state |= i2c_write(_DS1307_SLAVE_ADDR_W); /* Specify DS1307 slave with WRITE */
-    ack_state |= i2c_write(YEAR_ADDR);            /* Select year register */
-    i2c_start();                                  /* Issue RESTART condition */
-    ack_state |= i2c_write(_DS1307_SLAVE_ADDR_R); /* Specify DS1307 slave with READ */
-    *year = i2c_read(_AND_NACK);                  /* Read year register */
+    *val = i2c_read(_AND_NACK);                   /* Read register */
     i2c_stop();                                   /* Issue STOP condition */
 
     return (0 == ack_state) ? true : false;

--- a/firmware/src/drivers/ds1307.h
+++ b/firmware/src/drivers/ds1307.h
@@ -1,7 +1,12 @@
 /**
- * @file    ds1307.h
- * @author  Ghaadyy
- * @date    21/12/2024
+ * @file ds1307.h
+ * @author Ghady Youssef (ghadyyi@gmail.com)
+ * @brief The DS1307 driver.
+ * @version 0.2
+ * @date 2024-12-21
+ *
+ * @copyright Copyright (c) 2024
+ *
  */
 
 #ifndef _DS1307_H
@@ -20,21 +25,6 @@
 #define MONTH_ADDR (0x05)
 #define YEAR_ADDR (0x06)
 
-typedef struct date_info
-{
-    uint8_t day;   /*!< The day value represented in BCD */
-    uint8_t date;  /*!< The date value represented in BCD */
-    uint8_t month; /*!< The month value represented in BCD */
-    uint8_t year;  /*!< The year value represented in BCD */
-} date_info_t;
-
-typedef struct time_info
-{
-    uint16_t hours;   /*!< The hours value represented in BCD */
-    uint16_t minutes; /*!< The minutes value represented in BCD */
-    uint16_t seconds; /*!< The seconds value represented in BCD */
-} time_info_t;
-
 /**
  * @brief Initializes the DS1307 and sets the required register values.
  *
@@ -44,82 +34,13 @@ typedef struct time_info
 bool init_rtc(void);
 
 /**
- * @brief Get the date in BCD format
+ * @brief Reads a DS1307 register value.
  *
- * @return true
- * @return false
+ * @param reg_addr The register's address.
+ * @param val Pointer to the extracted value
+ * @return true if read operation was successfull
+ * @return false otherwise
  */
-bool get_full_date(date_info_t *bcd_date);
-
-/**
- * @brief Get the time in BCD format
- *
- * @return true
- * @return false
- */
-bool get_time(time_info_t *bcd_time);
-
-/**
- * @brief Get the hour in BCD format
- *
- * @param hour
- * @return true
- * @return false
- */
-bool get_hour(uint8_t *hour);
-
-/**
- * @brief Get the minutes in BCD format
- *
- * @param minutes
- * @return true
- * @return false
- */
-bool get_minutes(uint8_t *minutes);
-
-/**
- * @brief Get the seconds in BCD format
- *
- * @param seconds
- * @return true
- * @return false
- */
-bool get_seconds(uint8_t *seconds);
-
-/**
- * @brief Get the date in BCD format
- *
- * @param date
- * @return true
- * @return false
- */
-bool get_date(uint8_t *date);
-
-/**
- * @brief Get the day in BCD format
- *
- * @param day
- * @return true
- * @return false
- */
-bool get_day(uint8_t *day);
-
-/**
- * @brief Get the month in BCD format
- *
- * @param month
- * @return true
- * @return false
- */
-bool get_month(uint8_t *month);
-
-/**
- * @brief Get the year in BCD format
- *
- * @param year
- * @return true
- * @return false
- */
-bool get_year(uint8_t *year);
+bool read_reg(uint8_t reg_addr, uint8_t *val);
 
 #endif

--- a/firmware/src/elevator.ccspjt
+++ b/firmware/src/elevator.ccspjt
@@ -40,7 +40,7 @@ enabled=0
 chip=1
 D1=
 V1=
-buildcount=357
+buildcount=359
 
 [main.c]
 Type=4
@@ -59,7 +59,7 @@ Fixed=
 [Opened Files]
 1=main.c
 t1=1
-Count=16
+Count=19
 2=drivers\adc.h
 t2=1
 3=system.h
@@ -90,6 +90,12 @@ t14=1
 t15=1
 16=sched\scheduler.h
 t16=1
+17=api\cabin_display.c
+t17=61
+18=api\date.c
+t18=61
+19=api\date.h
+t19=3
 [..\output\misc_IOs.c]
 Type=4
 
@@ -309,7 +315,7 @@ Type=4
 [..\..\..\UART_int_Tasks\Firmware\output\elevator.c]
 Type=4
 [Units]
-Count=14
+Count=15
 1=main
 2=hardware
 3=system
@@ -324,4 +330,5 @@ Count=14
 12=api\elevator
 13=api\buttons
 14=api\queue
+15=api\date
 Link=1


### PR DESCRIPTION
## Description

- Moved the `get_day`, `get_month`, `get_year`, etc. to a date API
- Simplified DS1307 driver logic into a `read_reg` function
